### PR TITLE
fix 查词时，输入框下面应该会显示查词中的bug

### DIFF
--- a/app/src/main/java/name/gudong/translate/mvp/presenters/MainPresenter.java
+++ b/app/src/main/java/name/gudong/translate/mvp/presenters/MainPresenter.java
@@ -108,7 +108,7 @@ public class MainPresenter extends BasePresenter<IMainView>{
                 .doOnSubscribe(new Action0() {
                     @Override
                     public void call() {
-                        mView.onClearResultViews();
+
                     }
                 })
                 .observeOn(AndroidSchedulers.mainThread())
@@ -132,6 +132,7 @@ public class MainPresenter extends BasePresenter<IMainView>{
                 .flatMap(new Func1<List<String>, Observable<String>>() {
                     @Override
                     public Observable<String> call(List<String> strings) {
+                        mView.onClearResultViews();
                         if(strings == null){
                             return Observable.error(new Exception(("啥也没有翻译出来!")));
                         }


### PR DESCRIPTION
这个bug的原因是在执行了
````
mView.onPrepareTranslate();
````
之后,马上被

````
.doOnSubscribe(new Action0() {
                    @Override
                    public void call() {
                        mView.onClearResultViews();
                    }
                })
````
这里清除掉,实际上,应该在从网络解析结果完成后,再清理这个查词中的控件.这样.就能保证先显示查词中,网络返回结果后,再显示查词结果.