### PR TITLE
优化-生词本为空时,文本框显示没有收藏的单词

### DIFF
--- a/app/src/main/java/name/gudong/translate/ui/activitys/WordsBookActivity.java
+++ b/app/src/main/java/name/gudong/translate/ui/activitys/WordsBookActivity.java
@@ -26,6 +26,7 @@ import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.List;
@@ -41,10 +42,13 @@ import name.gudong.translate.reject.components.DaggerActivityComponent;
 import name.gudong.translate.reject.modules.ActivityModule;
 import name.gudong.translate.ui.adapter.WordsListAdapter;
 
-public class WordsBookActivity extends BaseActivity<BookPresenter> implements WordsListAdapter.OnClick,IBookView {
+public class WordsBookActivity extends BaseActivity<BookPresenter> implements WordsListAdapter.OnClick, IBookView {
 
     @Bind(R.id.rv_words_list)
     RecyclerView mRvWordsList;
+
+    @Bind(R.id.empty_tip_text)
+    TextView emptyTipText;
 
     WordsListAdapter mAdapter;
 
@@ -58,7 +62,7 @@ public class WordsBookActivity extends BaseActivity<BookPresenter> implements Wo
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_words_book);
         ButterKnife.bind(this);
-        initActionBar(true,"单词本");
+        initActionBar(true, "单词本");
         initListView();
         initData();
     }
@@ -91,12 +95,21 @@ public class WordsBookActivity extends BaseActivity<BookPresenter> implements Wo
 
     @Override
     public void fillData(List<Result> transResultEntities) {
-        mAdapter.update(transResultEntities);
+        //如果查出来的结果为空,那么提示用户没有收藏的单词
+        if (transResultEntities == null || transResultEntities.size() == 0) {
+            emptyTipText.setVisibility(View.VISIBLE);
+        } else {
+            emptyTipText.setVisibility(View.GONE);
+            mAdapter.update(transResultEntities);
+        }
     }
 
     @Override
     public void deleteWordSuccess(Result entity) {
         mAdapter.removeItem(entity);
+        if (mAdapter.getItemCount() == 0) {
+            emptyTipText.setVisibility(View.VISIBLE);
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/activity_words_book.xml
+++ b/app/src/main/res/layout/activity_words_book.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~  Copyright (C) 2015 GuDong <gudong.name@gmail.com>
   ~
   ~  This file is part of GdTranslate
@@ -19,16 +18,23 @@
   ~
   -->
 
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="name.gudong.translate.ui.activitys.WordsBookActivity">
 
+    <TextView
+        android:id="@+id/empty_tip_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/empty_tip"
+        android:visibility="visible" />
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/rv_words_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,5 +27,6 @@
     <string name="duration_four_second">4秒钟</string>
     <string name="duration_six_second">6秒钟</string>
     <string name="duration_ten_second">10秒钟</string>
+    <string name="empty_tip">没有收藏的单词</string>
 
 </resources>


### PR DESCRIPTION
整体思路:

单词本视图初始设置了一个TextView,展示没有收藏的单词.默认显示

1.当单词本填充结果为空的时候 .设置该控件可见
2.当单词本查询结果不为空的时候,设置控件不可见.单词本正常填充
3.添加删除单词本单词优化.当删除之后,单词本里不再有单词的时候.设置该控件可见.避免删除之后,显示空白屏幕.

