### PR TITLE
 check DrawOverlays permission before using it

### DIFF
--- a/app/src/main/java/name/gudong/translate/listener/view/TipViewController.java
+++ b/app/src/main/java/name/gudong/translate/listener/view/TipViewController.java
@@ -31,7 +31,6 @@ import android.graphics.PixelFormat;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.WindowManager;
 
@@ -72,6 +71,10 @@ public class TipViewController {
     }
 
     public void showErrorInfo(String error, TipView.ITipViewListener mListener) {
+        if (!Utils.checkDrawOverlaysPermissionGranted(mContext)) {
+            Logger.i("No DrawOverlays Permission, end translation operation");
+            return;
+        }
         TipView tipView = new TipView(mContext);
         tipView.setListener(mListener);
         mWindowManager.addView(tipView, getPopViewParams());
@@ -164,6 +167,10 @@ public class TipViewController {
             mNotificationManager.notify(result.getQuery().hashCode(), note);
 
         } else {
+            if (!Utils.checkDrawOverlaysPermissionGranted(mContext)) {
+                Logger.i("No DrawOverlays Permission, end translation operation");
+                return;
+            }
             TipView tipView = new TipView(mContext);
             mMapTipView.put(result, tipView);
             tipView.setListener(mListener);

--- a/app/src/main/java/name/gudong/translate/ui/activitys/MainActivity.java
+++ b/app/src/main/java/name/gudong/translate/ui/activitys/MainActivity.java
@@ -132,11 +132,10 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
         checkVersion();
         setUpDayline(false);
         checkIntent();
-        boolean needShowGuidePermissionDialog = checkOverPermission();
-        if(needShowGuidePermissionDialog){
-            showGuidePermissionDialog();
-        }else{
+        if (Utils.checkDrawOverlaysPermissionGranted(this)) {
             guideCheck();
+        } else {
+            showGuidePermissionDialog();
         }
     }
 
@@ -190,20 +189,6 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
         }
     }
 
-    private boolean checkOverPermission() {
-        if (Utils.isAndroidM()) {
-            if (!SpUtils.hasGrantDrawOverlays(this) && !Settings.canDrawOverlays(this)) {
-                return true;
-            } else {
-                SpUtils.setDrawOverlays(this, true);
-                return false;
-            }
-        } else {
-            SpUtils.setDrawOverlays(this, true);
-            return false;
-        }
-    }
-
     /**
      * 弹出引导用户打开悬浮权限的 dialog
      */
@@ -223,7 +208,7 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
                 .show();
     }
 
-    private void showFloatTranslateExplainDialog(){
+    private void showFloatTranslateExplainDialog() {
         DialogUtil.showGuideFloatTranslate(this);
     }
 
@@ -238,7 +223,7 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
     }
 
     private void initConfig() {
-        if(SpUtils.isAutoCompleteInputWords(this)){
+        if (SpUtils.isAutoCompleteInputWords(this)) {
             mPresenter.analysisLocalDic();
         }
     }
@@ -604,7 +589,7 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
                 dic);
         mInput.setAdapter(wordAdapter);
         mInput.setThreshold(1);
-        mInput.setDropDownHeight(Utils.dp2px(this,200));
+        mInput.setDropDownHeight(Utils.dp2px(this, 200));
         mInput.setOnItemClickListener((parent, view, position, id) -> translate());
     }
 
@@ -640,8 +625,8 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
 
 
     private void initSpinner() {
-        List<ETranslateFrom>translateWay = mPresenter.getTranslateWaysList();
-        ArrayAdapter<ETranslateFrom>arrayAdapter = new ArrayAdapter<>(this, R.layout.spinner_drop_list_title,translateWay);
+        List<ETranslateFrom> translateWay = mPresenter.getTranslateWaysList();
+        ArrayAdapter<ETranslateFrom> arrayAdapter = new ArrayAdapter<>(this, R.layout.spinner_drop_list_title, translateWay);
         arrayAdapter.setDropDownViewResource(R.layout.spinner_drop_list_item);
         mSpTranslateWay.setAdapter(arrayAdapter);
     }
@@ -684,18 +669,19 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
             super.onBackPressed();
         }
     }
+
     LottieAnimationView mAnimView;
 
     @Override
-    public void playNewYearAnim(){
-        if(mAnimView == null){
-            int size = Utils.dp2px(this,300);
+    public void playNewYearAnim() {
+        if (mAnimView == null) {
+            int size = Utils.dp2px(this, 300);
             mAnimView = new LottieAnimationView(this);
             mAnimView.setAnimation("lottie/new_year_fire.json");
             FrameLayout root = (FrameLayout) getWindow().getDecorView();
-            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(size,size);
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(size, size);
             params.gravity = Gravity.CENTER;
-            root.addView(mAnimView,params);
+            root.addView(mAnimView, params);
         }
         mAnimView.setVisibility(View.VISIBLE);
         mAnimView.addAnimatorListener(new AnimatorListenerAdapter() {
@@ -714,7 +700,7 @@ public class MainActivity extends BaseActivity<MainPresenter> implements IMainVi
         mAnimView.playAnimation();
     }
 
-    private void hideAnim(){
+    private void hideAnim() {
         mAnimView.setVisibility(View.GONE);
         mAnimView.setProgress(0);
         mAnimView.cancelAnimation();

--- a/app/src/main/java/name/gudong/translate/util/SpUtils.java
+++ b/app/src/main/java/name/gudong/translate/util/SpUtils.java
@@ -66,9 +66,6 @@ public class SpUtils {
     //App 是否在前台
     private static final String KEY_FLAG_APP_FRONT = "FLAG_LISTENER_CLIPBOARD";
 
-    //是否授予 Android M 浮窗权限
-    private static final String KEY_DRAW_OVERLAYS_PERMISSION = "DRAW_OVERLAYS_PERMISSION";
-
     //是否已经显示过用户引导
     private static final String KEY_HAS_SHOW_GUIDE = "HAS_SHOW_GUIDE";
 
@@ -116,15 +113,6 @@ public class SpUtils {
 
     public static boolean getAppFront(Context context){
         return getBooleanPreference(context, KEY_FLAG_APP_FRONT,false);
-    }
-
-    //设置是否匹配权限
-    public static void setDrawOverlays(Context context,boolean isOpen){
-        putBooleanPreference(context, KEY_DRAW_OVERLAYS_PERMISSION,isOpen);
-    }
-
-    public static boolean hasGrantDrawOverlays(Context context){
-        return getBooleanPreference(context, KEY_DRAW_OVERLAYS_PERMISSION,false);
     }
 
     public static boolean hasShowGuide(Context context){

--- a/app/src/main/java/name/gudong/translate/util/Utils.java
+++ b/app/src/main/java/name/gudong/translate/util/Utils.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
+import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
 
 import org.json.JSONArray;
@@ -139,5 +140,14 @@ public class Utils {
     public static int dp2px(Context context, float dpValue) {
         final float scale = context.getResources().getDisplayMetrics().density;
         return (int) (dpValue * scale + 0.5f);
+    }
+
+    /**
+     * @param context to get preference
+     * @return true on granted, false on fail
+     */
+    public static boolean checkDrawOverlaysPermissionGranted(Context context) {
+        //The result of `Settings.canDrawOverlays(context)` should not be saved, because you never know when your user would modify it
+        return !Utils.isAndroidM() || Settings.canDrawOverlays(context);
     }
 }


### PR DESCRIPTION
- If user didn't grant `DrawOverlays` permission on the startup page, when copying text to clipboard, it will cause a crash of `Permission Denied`
  - check permission before using it
- The result of `Settings.canDrawOverlays(context)` should not be saved, because you never know when your user would modify it
  - remove it in sf